### PR TITLE
Refactor to introduce suggested better practice across React and Ably

### DIFF
--- a/components/AblyNews.js
+++ b/components/AblyNews.js
@@ -1,23 +1,23 @@
 import React from "react";
 import { configureAbly } from "@ably-labs/react-hooks";
 import { generateRandomName } from "../lib/randomNames";
-import AblyPubSubComponent from "./AblyPubSubComponent";
-import AblyPresenceComponent from "./AblyPresenceComponent";
+import AblyPubSub from "./AblyPubSub";
+import AblyPresence from "./AblyPresence";
 
 const clientId = generateRandomName();
 
 /* Parent component that configures an instance of the Ably client
 and makes it available to the child components */
-const AblyNewsComponent = (props) => {
+const AblyNews = (props) => {
   configureAbly({ key: props.apiKey, clientId: clientId });
   return (
     <div>
       <h3>Participants</h3>
-      <AblyPresenceComponent clientId={clientId} />
+      <AblyPresence clientId={clientId} />
       <h3>Headlines</h3>
-      <AblyPubSubComponent />
+      <AblyPubSub />
     </div>
   );
 };
 
-export default AblyNewsComponent;
+export default AblyNews;

--- a/components/AblyPresence.js
+++ b/components/AblyPresence.js
@@ -4,7 +4,7 @@ import styles from "../styles/Home.module.css";
 
 /* Retrieves the Presence set from the "news-list" channel and lists
 the members using their client Id */
-const AblyPresenceComponent = (props) => {
+const AblyPresence = (props) => {
   const [presenceData] = usePresence("news-list");
 
   const presenceList = presenceData.map((member, index) => {
@@ -22,4 +22,4 @@ const AblyPresenceComponent = (props) => {
   return <div>{presenceList}</div>;
 };
 
-export default AblyPresenceComponent;
+export default AblyPresence;

--- a/components/AblyPubSub.js
+++ b/components/AblyPubSub.js
@@ -34,7 +34,6 @@ const AblyPubSub = () => {
   /* Process each message to retrieve the timestamp and author (client Id) */
   const HeadlinePreviews = ({items}) => {
     const previews = items.map((headline, index) => {
-      console.log(headline)
       const author =
         headline.clientId === ably.auth.clientId ? "(me)" : headline.clientId;
       return (

--- a/components/AblyPubSub.js
+++ b/components/AblyPubSub.js
@@ -20,22 +20,26 @@ const AblyPubSub = () => {
     updateHeadlines((prev) => [...prev, message]);
   });
 
+  const formatDate = (timestamp) => {
+    const dateToFormat = new Date(timestamp);
+    const formattedDate = "";
+    if (dateToFormat.getDate() === new Date().getDate()) {
+      formattedDate = `Today ${date.format(dateToFormat, "HH:mm:ss")}`;
+    } else {
+      formattedDate = date.format(dateToFormat, "ddd HH:mm:ss");
+    }
+    return formattedDate
+  }
+
   /* Process each message to retrieve the timestamp and author (client Id) */
   const headlinePreviews = headlines.map((headline, index) => {
-    const timestamp = new Date(headline.timestamp);
-    const formattedDate = "";
-    if (timestamp.getDate() === new Date().getDate()) {
-      formattedDate = `Today ${date.format(timestamp, "HH:mm:ss")}`;
-    } else {
-      formattedDate = date.format(timestamp, "ddd HH:mm:ss");
-    }
     const author =
       headline.clientId === ably.auth.clientId ? "(me)" : headline.clientId;
     return (
       <li key={index}>
         {headline.data}
         {"     "}
-        <span className={styles.timestamp}>{formattedDate}</span>{" "}
+        <span className={styles.timestamp}>{formatDate(headline.timestamp)}</span>{" "}
         <span className={styles.author}>{author}</span>
       </li>
     );

--- a/components/AblyPubSub.js
+++ b/components/AblyPubSub.js
@@ -42,7 +42,7 @@ const AblyPubSub = () => {
   });
 
   const sendNewHeadlineMessage = (headlineText) => {
-    channel.publish({ name: "news-list", data: headlineText });
+    channel.publish({ data: headlineText });
     setHeadlineText("");
     inputBox.focus();
   };

--- a/components/AblyPubSub.js
+++ b/components/AblyPubSub.js
@@ -41,8 +41,16 @@ const AblyPubSub = () => {
     );
   });
 
-  const sendNewHeadlineMessage = (headlineText) => {
-    channel.publish({ data: headlineText });
+  const sendNewHeadlineMessage = async (headlineText) => {
+    /* submit news to the server to verify and then publish */
+    await fetch('/api/submit-news', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({headline: headlineText})
+    });
+
     setHeadlineText("");
     inputBox.focus();
   };

--- a/components/AblyPubSub.js
+++ b/components/AblyPubSub.js
@@ -32,18 +32,23 @@ const AblyPubSub = () => {
   }
 
   /* Process each message to retrieve the timestamp and author (client Id) */
-  const headlinePreviews = headlines.map((headline, index) => {
-    const author =
-      headline.clientId === ably.auth.clientId ? "(me)" : headline.clientId;
-    return (
-      <li key={index}>
-        {headline.data}
-        {"     "}
-        <span className={styles.timestamp}>{formatDate(headline.timestamp)}</span>{" "}
-        <span className={styles.author}>{author}</span>
-      </li>
-    );
-  });
+  const HeadlinePreviews = ({items}) => {
+    const previews = items.map((headline, index) => {
+      console.log(headline)
+      const author =
+        headline.clientId === ably.auth.clientId ? "(me)" : headline.clientId;
+      return (
+        <li key={index}>
+          {headline.data}
+          {"     "}
+          <span className={styles.timestamp}>{formatDate(headline.timestamp)}</span>{" "}
+          <span className={styles.author}>{author}</span>
+        </li>
+      );
+    });
+
+    return <ul>{previews}</ul>;
+  };
 
   const sendNewHeadlineMessage = async (headlineText) => {
     /* submit news to the server to verify and then publish */
@@ -74,7 +79,9 @@ const AblyPubSub = () => {
 
   return (
     <div>
-      <div>{headlinePreviews}</div>
+      <div>
+        <HeadlinePreviews items={headlines} />
+      </div>
 
       <div
         ref={(element) => {

--- a/components/AblyPubSub.js
+++ b/components/AblyPubSub.js
@@ -6,7 +6,7 @@ import date from "date-and-time";
 /* Subscribes to headline messages from the "news-list" channel
 and provides a form to enter new headlines which it publishes to 
 the same channel */
-const AblyPubSubComponent = () => {
+const AblyPubSub = () => {
   let inputBox = null;
   let messageEnd = null;
 
@@ -93,4 +93,4 @@ const AblyPubSubComponent = () => {
   );
 };
 
-export default AblyPubSubComponent;
+export default AblyPubSub;

--- a/example.env
+++ b/example.env
@@ -1,1 +1,1 @@
-ABLY_API_KEY=ABLY_API_KEY=your.api-key:goes-here
+ABLY_API_KEY=your.api-key:goes-here

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@ably-labs/react-hooks": "^1.1.5",
+    "ably": "^1.2.20",
     "date-and-time": "^2.3.1",
     "next": "12.1.5",
     "react": "18.0.0",

--- a/pages/api/hello.js
+++ b/pages/api/hello.js
@@ -1,5 +1,0 @@
-// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-
-export default function handler(req, res) {
-  res.status(200).json({ name: 'John Doe' })
-}

--- a/pages/api/submit-news.js
+++ b/pages/api/submit-news.js
@@ -1,0 +1,16 @@
+const Ably = require('ably');
+
+const rest = new Ably.Rest(process.env.ABLY_API_KEY);
+
+var channel = rest.channels.get('news-list');
+
+export default function handler(req, res) {
+    if (req.method === 'POST') {
+        channel.publish([{data: req.body.headline}]);
+    
+        res.status(200).json({})
+    }
+    else {
+        res.status(405).json({})
+    }
+}

--- a/pages/api/submit-news.js
+++ b/pages/api/submit-news.js
@@ -4,9 +4,12 @@ const rest = new Ably.Rest(process.env.ABLY_API_KEY);
 
 var channel = rest.channels.get('news-list');
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
     if (req.method === 'POST') {
-        channel.publish([{data: req.body.headline}]);
+        channel.publish('new-headline', {
+            text: req.body.text,
+            author: req.body.author,
+        });
     
         res.status(200).json({})
     }

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,8 +6,8 @@ import Footer from "../components/Footer";
 
 /* By default, NextJS renders everything server-side during the build process. We 
 need to tell it not to do that here so that our components can connect to Ably's APIs */
-const AblyNewsComponent = dynamic(
-  () => import("../components/AblyNewsComponent"),
+const AblyNews = dynamic(
+  () => import("../components/AblyNews"),
   { ssr: false }
 );
 
@@ -29,7 +29,7 @@ export default function Home(props) {
         ></Image>
         <h1>Realtime News</h1>
 
-        <AblyNewsComponent apiKey={props.ablyApiKey} />
+        <AblyNews apiKey={props.ablyApiKey} />
       </main>
 
       <Footer />


### PR DESCRIPTION
Main changes:

- Publish takes place via a `fetch` to `/api/submit-news` (maybe it should be just `/news`) which means some validation/verification of the content could take place on the server vs. publishing on the client. If we agree with this change then we should use a subscribe only key on the client.
- Componentized as much as possible

Note: I may have broken something related to showing the `author` within the news headline. I'm not sure how this worked.

Additional consideration: would submitting a URL and then using Open Graph ([Node.js package](https://github.com/samholmes/node-open-graph)) to get a preview title reflect a more realistic and interesting use case?