### PR TITLE
Remove transpilation of Ably React Hooks and re-implement history via SSR (and ISR)

### DIFF
--- a/components/Articles.js
+++ b/components/Articles.js
@@ -3,15 +3,25 @@ import { useChannel } from "@ably-labs/react-hooks";
 import ArticlePreview from "./ArticlePreview";
 import styles from "../styles/Home.module.css";
 
+let clearHistoryState = true;
+
 export default function Articles(props) {
   let inputBox = null;
 
   const [headlineText, setHeadlineText] = useState("");
   const [headlines, updateHeadlines] = useState(props.history);
-  const [_, ably] = useChannel("headlines", (headline) => {
+  const [_, ably] = useChannel("[?rewind=5]headlines", (headline) => {
+    if (clearHistoryState) {
+      resetHeadlines();
+      clearHistoryState = false;
+    }
+
     updateHeadlines((prev) => [headline, ...prev]);
   });
 
+  const resetHeadlines = () => {
+    updateHeadlines([]);
+  };
   const headlineTextIsEmpty = headlineText.trim().length === 0;
 
   const processedHeadlines = headlines.map((headline) =>

--- a/components/Articles.js
+++ b/components/Articles.js
@@ -3,13 +3,13 @@ import { useChannel } from "@ably-labs/react-hooks";
 import ArticlePreview from "./ArticlePreview";
 import styles from "../styles/Home.module.css";
 
-export default function Articles() {
+export default function Articles(props) {
   let inputBox = null;
 
   const [headlineText, setHeadlineText] = useState("");
-  const [headlines, updateHeadlines] = useState([]);
-  const [_, ably] = useChannel("[?rewind=3]headlines", (headline) => {
-    updateHeadlines((prev) => [...prev, headline]);
+  const [headlines, updateHeadlines] = useState(props.history);
+  const [_, ably] = useChannel("headlines", (headline) => {
+    updateHeadlines((prev) => [headline, ...prev]);
   });
 
   const headlineTextIsEmpty = headlineText.trim().length === 0;

--- a/components/Articles.js
+++ b/components/Articles.js
@@ -3,6 +3,12 @@ import { useChannel } from "@ably-labs/react-hooks";
 import ArticlePreview from "./ArticlePreview";
 import styles from "../styles/Home.module.css";
 
+/* 
+clearHistoryState:
+  - When true, historical messages are retrieved and rendered statically from the History API.
+  - When false, historical messages are retrieved using channel rewind to prevent a race condition
+    where new messages are arriving on the channel while history is still being retrieved.
+*/
 let clearHistoryState = true;
 
 export default function Articles(props) {

--- a/lib/history.js
+++ b/lib/history.js
@@ -8,6 +8,10 @@ const channel = rest.channels.get("headlines");
 
 export async function getHistoricalMessages() {
   const resultPage = await channel.history({ limit: 5 });
+  /* 
+    See issue: https://github.com/vercel/next.js/issues/11993. The JSON must
+    be re-parsed or certain Message object items cannot be serialized by props later.
+  */
   const historicalMessages = JSON.parse(JSON.stringify(resultPage.items));
   return historicalMessages;
 }

--- a/lib/history.js
+++ b/lib/history.js
@@ -1,0 +1,13 @@
+import Ably from "ably";
+
+const rest = new Ably.Rest.Promise({
+  key: process.env.ABLY_SERVER_API_KEY,
+});
+
+const channel = rest.channels.get("headlines");
+
+export async function getHistoricalMessages() {
+  const resultPage = await channel.history({ limit: 5 });
+  const historicalMessages = JSON.parse(JSON.stringify(resultPage.items));
+  return historicalMessages;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 
-const withTM = require("next-transpile-modules")(["@ably-labs/react-hooks"]);
-const nextConfig = withTM({
+const nextConfig = {
   reactStrictMode: true,
   images: {
     domains: ["static.ably.dev", "res.cloudinary.com"],
@@ -27,6 +26,6 @@ const nextConfig = withTM({
       },
     ];
   },
-});
+};
 
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@ably-labs/react-hooks": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@ably-labs/react-hooks/-/react-hooks-2.0.1.tgz",
-      "integrity": "sha512-QyeCE8I80fL9XuFtFepazTZ3mFmFTwe3msmwCPM6wHDs97HMO3tVUlSsMcD9BbxFcaekWlpHm1dQcESxPzVNng==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@ably-labs/react-hooks/-/react-hooks-2.0.4.tgz",
+      "integrity": "sha512-RVOBsqUwRML8snaOibd7laoG2DJym4zMBzEoeeqiQvpQ2ZcEShapfWtnq23sXUxSc/1rJ6ReCiw7XuDg7rF06g==",
       "requires": {
         "ably": "^1.2.22"
       }
@@ -774,15 +774,6 @@
         "once": "^1.4.0"
       }
     },
-    "enhanced-resolve": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz",
-      "integrity": "sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==",
-      "requires": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
-      }
-    },
     "entities": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
@@ -838,11 +829,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -1377,11 +1363,6 @@
         "responselike": "^2.0.0"
       }
     },
-    "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -1836,15 +1817,6 @@
         "caniuse-lite": "^1.0.30001332",
         "postcss": "8.4.5",
         "styled-jsx": "5.0.2"
-      }
-    },
-    "next-transpile-modules": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/next-transpile-modules/-/next-transpile-modules-9.0.0.tgz",
-      "integrity": "sha512-VCNFOazIAnXn1hvgYYSTYMnoWgKgwlYh4lm1pKbSfiB3kj5ZYLcKVhfh3jkPOg1cnd9DP+pte9yCUocdPEUBTQ==",
-      "requires": {
-        "enhanced-resolve": "^5.7.0",
-        "escalade": "^3.1.1"
       }
     },
     "normalize-url": {
@@ -2353,11 +2325,6 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
-    },
-    "tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@ably-labs/react-hooks": "^2.0.1",
+    "@ably-labs/react-hooks": "^2.0.4",
     "ably": "^1.2.25",
     "next": "12.1.6",
-    "next-transpile-modules": "^9.0.0",
     "open-graph-scraper": "^4.11.0",
     "react": "18.1.0",
     "react-dom": "18.1.0",

--- a/pages/api/hello.js
+++ b/pages/api/hello.js
@@ -1,5 +1,0 @@
-// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-
-export default function handler(req, res) {
-  res.status(200).json({ name: 'John Doe' })
-}

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,12 +5,13 @@ import styles from "../styles/Home.module.css";
 import Participants from "../components/Participants";
 import { configureAbly } from "@ably-labs/react-hooks";
 import Articles from "../components/Articles";
+import { getHistoricalMessages } from "../lib/history";
 
 configureAbly({
   authUrl: `${process.env.NEXT_PUBLIC_HOSTNAME}/api/createTokenRequest`,
 });
 
-export default function Home() {
+export default function Home(props) {
   return (
     <div className={styles.container}>
       <Head>
@@ -34,8 +35,20 @@ export default function Home() {
         <h2>Share your favorite news articles</h2>
         <h3>Participants</h3>
         <Participants />
-        <Articles />
+        <Articles history={props.history} />
       </main>
     </div>
   );
+}
+
+export async function getStaticProps() {
+  const historicalMessages = await getHistoricalMessages();
+
+  return {
+    props: {
+      history: historicalMessages,
+    },
+    //enable ISR
+    revalidate: 10,
+  };
 }


### PR DESCRIPTION
@leggetter I was hoping you could have a look at this before I adjust the blog post as per your request.

Items addressed:

(1) Removed the whole `next-transpile-modules` workflow for Ably React Hooks. Jo Franchetti has updated the React Hooks package so that, as of v2.0.4, this is no longer required.

(2) Re-implemented History. For context, this is why Jo removed it:

> Using rewind instead of the history API, fewer roundtrips to the server, also ensures correct message order.

and

> deleted because if you are connecting to a channel and need to get its history, you should use rewind to prevent race conditions where current messages arrive on the channel as history is being retrieved, which could lead to message ordering issues during render.

I haven't noticed any issues with either of the above. The way is works is that, when the `index.js` page is loaded, there is a call to `getStaticProps` to retrieve the last five items from history and then any further updates are retrieved in realtime. I can specify [ISR (incremetal static regeneration)](https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration) with the `revalidate` property in that function (see code comment), but I don't really see the point. There is only ever a single call to history when the page first loads and all newer articles appear in realtime.

I'd like to know your thoughts on this before I rewrite the affected portions of the blog post? Thanks :)